### PR TITLE
Refactor: Restructure ML pipeline into modular training, evaluation, and registration scripts

### DIFF
--- a/movie-mlops-project/model/evaluate.py
+++ b/movie-mlops-project/model/evaluate.py
@@ -1,94 +1,123 @@
 import logging
 import os
+import sys
+import argparse
 
 import mlflow
-import numpy as np
+import mlflow.xgboost
 import pandas as pd
+import numpy as np
 
-from model.utils import evaluate_model, get_config_value, load_data, load_feature_names, load_model
+from dotenv import load_dotenv
 
-logging.basicConfig(
-    level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'
-)
+# ✅ 루트 경로 설정 및 환경 설정
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.append(project_root)
 
+# ✅ .env 로드 (AWS 자격 정보용)
+load_dotenv() 
 
-def evaluate_and_log_model(model, mlflow_run_id: str):
+from model.utils import evaluate_model, get_config_value, load_data, load_feature_names
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def evaluate_and_log_model(run_id: str,
+                           test_filepath: str,
+                           feature_names: list,
+                           target_column: str,
+                           mlflow_tracking_uri: str,
+                           mlflow_experiment_name: str) -> dict:
     """
-    주어진 모델을 테스트 데이터로 평가하고 MLflow에 지표를 로깅합니다.
+    MLflow Run ID를 기반으로 모델을 로드하고, 테스트 데이터로 평가한 후
+    해당 Run에 지표를 로깅합니다.
     """
-    try:
-        config_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), '..', 'config', 'config.yaml'
-        )
+    logging.info(f"MLflow Run ID: {run_id}의 모델을 평가합니다.")
 
-        processed_data_dir = get_config_value(config_path, 'data.processed_data_dir')
-        test_data_file = get_config_value(config_path, 'data.test_data_file')
-        feature_names_file = get_config_value(config_path, 'data.feature_names_file')
-        target_column = get_config_value(config_path, 'model.target_column')
-        mlflow_tracking_uri = get_config_value(config_path, 'mlflow.tracking_uri')
+    mlflow.set_tracking_uri(mlflow_tracking_uri)
+    mlflow.set_experiment(mlflow_experiment_name)
 
-        mlflow.set_tracking_uri(mlflow_tracking_uri)
-        mlflow.set_experiment("Movie Rating Prediction")
-
-        with mlflow.start_run(run_id=mlflow_run_id) as run:
-            logging.info(f"MLflow Run '{run.info.run_id}'에 재참여하여 모델 평가 시작")
-
-            project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            test_filepath = os.path.join(
-                project_root, processed_data_dir, test_data_file
-            )
-            feature_names_filepath = os.path.join(
-                project_root, processed_data_dir, feature_names_file
-            )
-
+    # MLflow에 저장된 모델 아티팩트 URI
+    model_uri = f"runs:/{run_id}/model"
+    
+    with mlflow.start_run(run_id=run_id) as run:
+        logging.info(f"MLflow Run '{run.info.run_id}'에 재참여하여 모델 평가 시작")
+        
+        try:
+            # ✅ MLflow 아티팩트에서 모델 로드
+            model = mlflow.xgboost.load_model(model_uri)
+            logging.info(f"MLflow 아티팩트에서 모델 로드 완료: {model_uri}")
+            
             test_df = load_data(test_filepath)
-            feature_names = load_feature_names(feature_names_filepath)
-
             X_test = test_df[feature_names]
             y_test = test_df[target_column]
 
-            logging.info(
-                f"테스트 데이터 X_test shape: {X_test.shape}, y_test shape: {y_test.shape}"
-            )
+            logging.info(f"테스트 데이터 X_test shape: {X_test.shape}, y_test shape: {y_test.shape}")
 
             y_pred = model.predict(X_test)
             metrics = evaluate_model(y_test, y_pred)
 
             mlflow.log_metrics(metrics)
-            logging.info("MLflow에 평가 지표 로깅 완료")
+            logging.info(f"MLflow에 평가 지표 로깅 완료: {metrics}")
 
             return metrics
 
-    except Exception as e:
-        logging.error(f"모델 평가 중 치명적인 오류 발생: {e}", exc_info=True)
-        raise
+        except Exception as e:
+            logging.error(f"모델 평가 중 오류 발생: {e}", exc_info=True)
+            raise
 
 
 if __name__ == "__main__":
-    logging.warning(
-        "단독 실행: 테스트 모델 로드. 주로 파이프라인에서 호출됩니다."
-    )
+    parser = argparse.ArgumentParser(description="모델 평가 스크립트")
+    parser.add_argument("--run_id", type=str, help="평가할 MLflow Run ID (지정하지 않으면 최신 Run을 사용)", default=None)
+    args = parser.parse_args()
 
     try:
-        config_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), '..', 'config', 'config.yaml'
-        )
-        model_output_dir = get_config_value(config_path, 'model.output_dir')
-        model_filename = get_config_value(config_path, 'model.filename')
-        model_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            model_output_dir,
-            model_filename,
-        )
+        # ✅ config 경로 설정 및 값 로딩
+        config_path = os.path.join(project_root, 'config', 'config.yaml')
+        processed_data_dir = get_config_value(config_path, 'data.processed_data_dir')
+        test_data_file = get_config_value(config_path, 'data.test_data_file')
+        feature_names_file = get_config_value(config_path, 'data.feature_names_file')
+        target_column = get_config_value(config_path, 'model.target_column')
+        mlflow_tracking_uri = get_config_value(config_path, 'mlflow.tracking_uri')
+        mlflow_experiment_name = get_config_value(config_path, 'mlflow.experiment_name')
 
-        if os.path.exists(model_path):
-            trained_model = load_model(model_path)
-            with mlflow.start_run(run_name="Evaluate_Standalone_Test") as temp_run:
-                metrics = evaluate_and_log_model(trained_model, temp_run.info.run_id)
-                logging.info(f"단독 실행 평가 완료. 결과: {metrics}")
-        else:
-            logging.error(
-                f"모델 파일이 없습니다: {model_path}. 먼저 train.py를 실행하여 모델을 학습시키세요."
-            )
+        mlflow.set_tracking_uri(mlflow_tracking_uri)
+        client = mlflow.tracking.MlflowClient()
+
+        # ✅ 평가할 Run ID 결정
+        run_id_to_evaluate = args.run_id
+        if run_id_to_evaluate is None:
+            logging.info("Run ID가 지정되지 않아 최신 Run을 자동으로 찾습니다.")
+            experiment = client.get_experiment_by_name(mlflow_experiment_name)
+            if experiment:
+                runs = client.search_runs(
+                    experiment_ids=[experiment.experiment_id],
+                    order_by=["start_time DESC"],
+                    max_results=1
+                )
+                if runs:
+                    run_id_to_evaluate = runs[0].info.run_id
+                    logging.info(f"최신 Run ID: {run_id_to_evaluate}를 사용합니다.")
+                else:
+                    logging.error("지정된 실험에 Run이 존재하지 않습니다.")
+                    sys.exit(1)
+            else:
+                logging.error(f"실험 '{mlflow_experiment_name}'을 찾을 수 없습니다.")
+                sys.exit(1)
+
+        # ✅ 모델 평가 실행
+        metrics = evaluate_and_log_model(
+            run_id=run_id_to_evaluate,
+            test_filepath=os.path.join(project_root, processed_data_dir, test_data_file),
+            feature_names=load_feature_names(os.path.join(project_root, processed_data_dir, feature_names_file)),
+            target_column=target_column,
+            mlflow_tracking_uri=mlflow_tracking_uri,
+            mlflow_experiment_name=mlflow_experiment_name
+        )
+        
+        logging.info(f"✅ 모델 평가 완료. 결과: {metrics}")
+
     except Exception as e:
-        logging.error(f"단독 실행 평가 중 오류 발생: {e}")
+        logging.error(f"스크립트 실행 중 오류 발생: {e}", exc_info=True)
+        sys.exit(1)

--- a/movie-mlops-project/model/register_mlflow.py
+++ b/movie-mlops-project/model/register_mlflow.py
@@ -1,52 +1,87 @@
 import logging
 import os
+import sys
+import argparse
 
 import mlflow
-import mlflow.xgboost
+from mlflow.entities import ViewType
+from mlflow.tracking import MlflowClient
 
-from model.utils import get_config_value, load_model, save_model
+from dotenv import load_dotenv
 
-logging.basicConfig(
-    level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'
-)
+# ✅ 루트 경로 설정 및 환경 설정
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.append(project_root)
 
+# ✅ .env 로드 (AWS 자격 정보용)
+load_dotenv()
 
-def register_and_save_model(model, mlflow_run_id: str):
+from model.utils import get_config_value, save_model, load_model
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def find_best_run_id(client: MlflowClient, experiment_name: str, metric_name: str = "rmse") -> str:
     """
-    학습된 모델을 MLflow에 아티팩트로 저장하고 모델 레지스트리에 등록하며,
-    로컬 파일 시스템에도 저장합니다.
+    MLflow Tracking API를 사용하여 주어진 실험에서 가장 낮은 지표를 가진 Run의 ID를 반환합니다.
     """
+    logging.info(f"실험 '{experiment_name}'에서 최적의 Run ID를 찾고 있습니다.")
+    experiment = client.get_experiment_by_name(experiment_name)
+    
+    if not experiment:
+        raise ValueError(f"실험 '{experiment_name}'을 찾을 수 없습니다.")
+
+    # 가장 낮은 지표를 가진 Run을 검색
+    runs = client.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        run_view_type=ViewType.ACTIVE_ONLY,
+        order_by=[f"metrics.{metric_name} ASC"],  # RMSE는 낮을수록 좋으므로 ASC (오름차순)
+        max_results=1
+    )
+
+    if not runs:
+        raise ValueError(f"실험 '{experiment_name}'에 유효한 Run이 없습니다.")
+
+    best_run = runs[0]
+    logging.info(f"최적의 Run을 찾았습니다. Run ID: {best_run.info.run_id}, {metric_name}: {best_run.data.metrics[metric_name]:.4f}")
+    
+    return best_run.info.run_id
+
+def register_and_save_model(best_run_id: str,
+                            model_registry_name: str,
+                            model_output_dir: str,
+                            model_filename: str):
+    """
+    주어진 Run ID의 모델을 MLflow 모델 레지스트리에 등록하고 로컬에 저장합니다.
+    """
+    logging.info(f"최적 Run ID '{best_run_id}'의 모델을 레지스트리에 등록 및 로컬에 저장합니다.")
+
+    # MLflow에 저장된 모델 아티팩트 URI
+    model_uri = f"runs:/{best_run_id}/model"
+    
     try:
-        config_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), '..', 'config', 'config.yaml'
+        # ✅ MLflow 모델 레지스트리에 등록
+        # mlflow.register_model 함수는 모델 아티팩트 URI를 통해 등록을 수행
+        registered_model = mlflow.register_model(
+            model_uri=model_uri,
+            name=model_registry_name
+        )
+        
+        logging.info(
+            f"모델 레지스트리에 등록 완료. 이름: {registered_model.name}, 버전: {registered_model.version}"
         )
 
-        model_output_dir = get_config_value(config_path, 'model.output_dir')
-        model_filename = get_config_value(config_path, 'model.filename')
-        mlflow_tracking_uri = get_config_value(config_path, 'mlflow.tracking_uri')
-        model_registry_name = get_config_value(config_path, 'mlflow.model_registry_name')
+        # ✅ 로컬 파일 시스템에 모델 저장
+        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        model_save_path = os.path.join(project_root, model_output_dir, model_filename)
 
-        mlflow.set_tracking_uri(mlflow_tracking_uri)
-        mlflow.set_experiment("Movie Rating Prediction")
-
-        with mlflow.start_run(run_id=mlflow_run_id) as run:
-            logging.info(f"MLflow Run '{run.info.run_id}'에 재참여하여 모델 등록 및 저장 시작")
-
-            mlflow.xgboost.log_model(
-                xgb_model=model,
-                artifact_path="xgboost-model",
-                registered_model_name=model_registry_name
-            )
-            logging.info(
-                f"MLflow에 모델 아티팩트 '{model_registry_name}' 로깅 및 레지스트리 등록 완료"
-            )
-
-            project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            model_save_path = os.path.join(project_root, model_output_dir, model_filename)
-
-            os.makedirs(os.path.dirname(model_save_path), exist_ok=True)
-            save_model(model, model_save_path)
-            logging.info(f"모델을 로컬에 저장했습니다: {model_save_path}")
+        os.makedirs(os.path.dirname(model_save_path), exist_ok=True)
+        
+        # 아티팩트에서 모델을 로드한 후 로컬에 저장
+        model_to_save = mlflow.xgboost.load_model(model_uri)
+        save_model(model_to_save, model_save_path)
+        
+        logging.info(f"모델을 로컬에 저장했습니다: {model_save_path}")
 
     except Exception as e:
         logging.error(f"모델 등록 및 저장 중 치명적인 오류 발생: {e}", exc_info=True)
@@ -54,28 +89,38 @@ def register_and_save_model(model, mlflow_run_id: str):
 
 
 if __name__ == "__main__":
-    logging.warning(
-        "단독 실행: 테스트 모델 로드. 주로 파이프라인에서 호출됩니다."
-    )
+    parser = argparse.ArgumentParser(description="최적의 모델을 MLflow에 등록하고 로컬에 저장하는 스크립트")
+    parser.add_argument("--run_id", type=str, help="등록할 MLflow Run ID (지정하지 않으면 최적의 Run을 자동으로 찾음)", default=None)
+    args = parser.parse_args()
 
     try:
-        config_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), '..', 'config', 'config.yaml'
-        )
+        # ✅ config 경로 설정 및 값 로딩
+        config_path = os.path.join(project_root, 'config', 'config.yaml')
+        mlflow_tracking_uri = get_config_value(config_path, 'mlflow.tracking_uri')
+        mlflow_experiment_name = get_config_value(config_path, 'mlflow.experiment_name')
+        model_registry_name = get_config_value(config_path, 'mlflow.model_registry_name')
         model_output_dir = get_config_value(config_path, 'model.output_dir')
         model_filename = get_config_value(config_path, 'model.filename')
 
-        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        model_path = os.path.join(project_root, model_output_dir, model_filename)
+        mlflow.set_tracking_uri(mlflow_tracking_uri)
+        client = MlflowClient()
 
-        if os.path.exists(model_path):
-            trained_model = load_model(model_path)
-            with mlflow.start_run(run_name="Register_Standalone_Test") as temp_run:
-                register_and_save_model(trained_model, temp_run.info.run_id)
-                logging.info("단독 실행 모델 등록 및 저장 완료.")
-        else:
-            logging.error(
-                f"모델 파일이 없습니다: {model_path}. 먼저 train.py를 실행하여 모델을 학습시키세요."
-            )
+        # ✅ 등록할 Run ID 결정
+        run_id_to_register = args.run_id
+        if run_id_to_register is None:
+            logging.info("Run ID가 지정되지 않아 최적의 Run을 자동으로 찾습니다.")
+            run_id_to_register = find_best_run_id(client, mlflow_experiment_name, "rmse")
+
+        # ✅ 모델 등록 및 저장 실행
+        register_and_save_model(
+            best_run_id=run_id_to_register,
+            model_registry_name=model_registry_name,
+            model_output_dir=model_output_dir,
+            model_filename=model_filename
+        )
+        
+        logging.info("✅ 모델 등록 및 로컬 저장 완료.")
+
     except Exception as e:
-        logging.error(f"단독 실행 모델 등록 및 저장 중 오류 발생: {e}")
+        logging.error(f"스크립트 실행 중 오류 발생: {e}", exc_info=True)
+        sys.exit(1)

--- a/movie-mlops-project/model/train_mlflow.py
+++ b/movie-mlops-project/model/train_mlflow.py
@@ -1,0 +1,118 @@
+import logging
+import os
+import sys
+import argparse
+
+import mlflow
+import mlflow.xgboost
+import pandas as pd
+import xgboost as xgb
+from dotenv import load_dotenv
+
+# ✅ 루트 경로 설정 및 환경 설정
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.append(project_root)
+
+# ✅ .env 로드 (AWS 자격 정보용)
+load_dotenv()
+
+from model.utils import get_config_value, load_data, load_feature_names
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def train_model(
+    train_filepath: str,
+    target_column: str,
+    feature_names: list,
+    xgb_params: dict,
+    mlflow_tracking_uri: str,
+    mlflow_experiment_name: str
+) -> None:
+    """
+    XGBoost 모델을 학습하고 MLflow에 로깅합니다.
+    - 모델 레지스트리 등록 및 로컬 저장 로직은 이 함수에서 제외됩니다.
+    """
+    logging.info("모델 학습을 시작합니다.")
+
+    mlflow.set_tracking_uri(mlflow_tracking_uri)
+    mlflow.set_experiment(mlflow_experiment_name)
+
+    run_name = f"XGBoost_Train_MaxDepth_{xgb_params.get('max_depth', 'default')}_Eta_{xgb_params.get('eta', 'default')}"
+    with mlflow.start_run(run_name=run_name) as run:
+        run_id = run.info.run_id
+        logging.info(f"MLflow Run ID: {run_id}으로 모델 학습 시작")
+
+        try:
+            train_df = load_data(train_filepath)
+            X_train = train_df[feature_names]
+            y_train = train_df[target_column]
+
+            logging.info(f"학습 데이터 X_train shape: {X_train.shape}, y_train shape: {y_train.shape}")
+
+            mlflow.log_params(xgb_params)
+            logging.info(f"MLflow에 파라미터 로깅 완료: {xgb_params}")
+
+            model = xgb.XGBRegressor(**xgb_params)
+            logging.info("XGBoost 모델 학습 시작")
+            model.fit(X_train, y_train)
+            logging.info("XGBoost 모델 학습 완료")
+
+            mlflow.xgboost.log_model(
+                xgb_model=model,
+                artifact_path="model",
+            )
+            logging.info("MLflow에 모델 아티팩트 로깅 완료 (레지스트리 등록 제외)")
+
+            return
+
+        except Exception as e:
+            logging.error(f"모델 학습 중 오류 발생: {e}", exc_info=True)
+            mlflow.end_run(status="FAILED")
+            raise
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="XGBoost 모델 학습 스크립트")
+    parser.add_argument("--max_depth", type=int, help="XGBoost max_depth 파라미터 (기본값을 오버라이드)")
+    parser.add_argument("--eta", type=float, help="XGBoost eta (learning_rate) 파라미터 (기본값을 오버라이드)")
+    args = parser.parse_args()
+
+    try:
+        # ✅ config 경로 설정
+        config_path = os.path.join(project_root, 'config', 'config.yaml')
+
+        # ✅ config 값 로딩
+        processed_data_dir = get_config_value(config_path, 'data.processed_data_dir')
+        train_data_file = get_config_value(config_path, 'data.train_data_file')
+        feature_names_file = get_config_value(config_path, 'data.feature_names_file')
+        target_column = get_config_value(config_path, 'model.target_column')
+        base_xgb_params = get_config_value(config_path, 'model.xgboost_params')
+
+        mlflow_tracking_uri = get_config_value(config_path, 'mlflow.tracking_uri')
+        mlflow_experiment_name = get_config_value(config_path, 'mlflow.experiment_name')
+
+        # ✅ 명령줄 인자 반영
+        current_xgb_params = base_xgb_params.copy()
+        if args.max_depth is not None:
+            current_xgb_params['max_depth'] = args.max_depth
+            logging.info(f"max_depth 인자 오버라이드: {args.max_depth}")
+        if args.eta is not None:
+            current_xgb_params['eta'] = args.eta
+            logging.info(f"eta 인자 오버라이드: {args.eta}")
+
+        # ✅ 학습 실행 (반환값 없음)
+        train_model(
+            train_filepath=os.path.join(project_root, processed_data_dir, train_data_file),
+            target_column=target_column,
+            feature_names=load_feature_names(os.path.join(project_root, processed_data_dir, feature_names_file)),
+            xgb_params=current_xgb_params,
+            mlflow_tracking_uri=mlflow_tracking_uri,
+            mlflow_experiment_name=mlflow_experiment_name,
+        )
+
+        logging.info("✅ 모델 학습 완료. MLflow에 결과가 기록되었습니다.")
+
+    except Exception as e:
+        logging.error(f"스크립트 실행 중 오류 발생: {e}", exc_info=True)
+        sys.exit(1)


### PR DESCRIPTION
## 📘 각 스크립트 역할 요약

### 🔹 `train_mlflow.py` — 모델 학습 및 실험 기록
- 다양한 하이퍼파라미터로 XGBoost 모델 학습
- `mlflow.start_run()`을 통해 Run 생성
- `mlflow.log_params()`로 파라미터 로깅
- `mlflow.xgboost.log_model()`로 모델을 S3에 저장  
  → ❌ **MLflow Registry에는 등록하지 않음**

---

### 🔹 `evaluate.py` — 모델 성능 평가
- 지정된 Run ID 또는 최신 Run의 모델을 로딩
- 테스트 데이터를 사용하여 모델 성능 평가 (RMSE, MAE 등)
- 평가 지표를 해당 Run에 `mlflow.log_metrics()`로 기록

---

### 🔹 `register_mlflow.py` — 최적 모델 등록 및 저장
- 실험 중 가장 낮은 RMSE를 기록한 Run 자동 탐색
- 해당 모델을 `mlflow.register_model()`로 Registry에 등록
- `mlflow.xgboost.load_model()`로 모델을 불러와 `.pkl`로 저장  
  → ✅ FastAPI 모델 서빙용으로 로컬 저장

---
